### PR TITLE
Enable drag region workaround

### DIFF
--- a/CoreAppUWP/CoreAppUWP.csproj
+++ b/CoreAppUWP/CoreAppUWP.csproj
@@ -12,7 +12,7 @@
     <PublishProfile>win10-$(Platform).pubxml</PublishProfile>
     <RepositoryUrl>https://github.com/wherewhere/CoreAppUWP</RepositoryUrl>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
-    <TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net7.0-windows10.0.22621.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <TrimMode>partial</TrimMode>
     <UseWinUI>True</UseWinUI>

--- a/CoreAppUWP/Helpers/UIHelper.cs
+++ b/CoreAppUWP/Helpers/UIHelper.cs
@@ -3,12 +3,19 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Windows.Foundation.Metadata;
+using Windows.Graphics.Display;
 
 namespace CoreAppUWP.Helpers
 {
     public static class UIHelper
     {
         public static bool HasStatusBar => ApiInformation.IsTypePresent("Windows.UI.ViewManagement.StatusBar");
+
+        public static int GetActualPixel(this double pixel)
+        {
+            double currentDpi = DisplayInformation.GetForCurrentView().RawPixelsPerViewPixel;
+            return Convert.ToInt32(pixel * currentDpi);
+        }
 
         public static string ExceptionToMessage(this Exception ex)
         {

--- a/CoreAppUWP/Helpers/WindowHelper.cs
+++ b/CoreAppUWP/Helpers/WindowHelper.cs
@@ -1,4 +1,6 @@
 ﻿using CoreAppUWP.Common;
+using Microsoft.UI;
+using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using System;
 using System.Collections.Generic;
@@ -6,6 +8,9 @@ using System.Threading.Tasks;
 using Windows.ApplicationModel.Core;
 using Windows.UI.Core;
 using Windows.UI.ViewManagement;
+using Windows.Win32.Foundation;
+using Windows.Win32.System.WinRT;
+using WinRT;
 
 namespace CoreAppUWP.Helpers
 {
@@ -48,6 +53,24 @@ namespace CoreAppUWP.Helpers
             }
         }
 
+        public static AppWindow GetAppWindow(this CoreWindow window)
+        {
+            if (!ActiveAppWindows.TryGetValue(window, out AppWindow appWindow))
+            {
+                HWND handle = window.As<ICoreWindowInterop>().WindowHandle;
+                WindowId id = Win32Interop.GetWindowIdFromWindow(handle);
+                appWindow = AppWindow.GetFromWindowId(id);
+                window.Closed += (sender, args) =>
+                {
+                    ActiveAppWindows.Remove(window);
+                    window = null;
+                };
+                ActiveAppWindows[window] = appWindow;
+            }
+            return appWindow;
+        }
+
         public static Dictionary<CoreDispatcher, Window> ActiveWindows { get; } = [];
+        public static Dictionary<CoreWindow, AppWindow> ActiveAppWindows { get; } = [];
     }
 }

--- a/CoreAppUWP/Pages/MainPage.xaml
+++ b/CoreAppUWP/Pages/MainPage.xaml
@@ -16,10 +16,13 @@
             Height="48"
             VerticalAlignment="Top"
             Canvas.ZIndex="1"
-            IsHitTestVisible="True">
+            IsHitTestVisible="True"
+            SizeChanged="CustomTitleBar_SizeChanged">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition x:Name="LeftPaddingColumn" Width="0" />
-                <ColumnDefinition x:Name="DragColumn" Width="*"/>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
                 <ColumnDefinition x:Name="RightPaddingColumn" Width="0" />
             </Grid.ColumnDefinitions>
             <Grid.ChildrenTransitions>
@@ -54,10 +57,12 @@
                     TextTrimming="CharacterEllipsis"
                     TextWrapping="NoWrap" />
             </Grid>
-            <Grid
+            <Border
                 x:Name="DragRegion"
                 Grid.Column="1"
-                Loaded="DragRegion_Loaded"
+                Grid.ColumnSpan="4"
+                HorizontalAlignment="Stretch"
+                VerticalAlignment="Stretch"
                 Background="{ThemeResource SystemControlTransparentBrush}" />
         </Grid>
         <NavigationView

--- a/CoreAppUWP/Pages/MainPage.xaml
+++ b/CoreAppUWP/Pages/MainPage.xaml
@@ -17,9 +17,7 @@
             IsHitTestVisible="True">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition x:Name="LeftPaddingColumn" Width="0" />
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition x:Name="DragColumn" Width="*"/>
                 <ColumnDefinition x:Name="RightPaddingColumn" Width="0" />
             </Grid.ColumnDefinitions>
             <Grid.ChildrenTransitions>
@@ -57,7 +55,7 @@
             <Grid
                 x:Name="DragRegion"
                 Grid.Column="1"
-                Grid.ColumnSpan="3"
+                Loaded="DragRegion_Loaded"
                 Background="{ThemeResource SystemControlTransparentBrush}" />
         </Grid>
         <NavigationView

--- a/CoreAppUWP/Pages/MainPage.xaml.cs
+++ b/CoreAppUWP/Pages/MainPage.xaml.cs
@@ -1,7 +1,5 @@
 ﻿using CoreAppUWP.Helpers;
 using CoreAppUWP.Pages.SettingsPages;
-using Microsoft.UI;
-using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media.Animation;
@@ -10,11 +8,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Windows.ApplicationModel.Core;
+using Windows.Graphics;
 using Windows.UI.Core;
-using Windows.Win32.System.WinRT;
-using WinRT.Interop;
-using WinRT;
-using System.Runtime.InteropServices;
 
 
 // To learn more about WinUI, the WinUI project structure,
@@ -187,65 +182,11 @@ namespace CoreAppUWP.Pages
                 e.Handled = TryGoBack();
             }
         }
-        [DllImport("Shcore.dll", SetLastError = true)]
-        internal static extern int GetDpiForMonitor(IntPtr hmonitor, Monitor_DPI_Type dpiType, out uint dpiX, out uint dpiY);
 
-        internal enum Monitor_DPI_Type : int
+        private void CustomTitleBar_SizeChanged(object sender, SizeChangedEventArgs e)
         {
-            MDT_Effective_DPI = 0,
-            MDT_Angular_DPI = 1,
-            MDT_Raw_DPI = 2,
-            MDT_Default = MDT_Effective_DPI
-        }
-
-        private double GetScaleAdjustment(IntPtr hWnd)
-        {
-            WindowId wndId = Win32Interop.GetWindowIdFromWindow(hWnd);
-            DisplayArea displayArea = DisplayArea.GetFromWindowId(wndId, DisplayAreaFallback.Primary);
-            IntPtr hMonitor = Win32Interop.GetMonitorFromDisplayId(displayArea.DisplayId);
-
-            // Get DPI.
-            int result = GetDpiForMonitor(hMonitor, Monitor_DPI_Type.MDT_Default, out uint dpiX, out uint _);
-            if (result != 0)
-            {
-                throw new Exception("Could not get DPI for monitor.");
-            }
-
-            uint scaleFactorPercent = (uint)(((long)dpiX * 100 + (96 >> 1)) / 96);
-            return scaleFactorPercent / 100.0;
-        }
-
-        private void DragRegion_Loaded(object sender, RoutedEventArgs e)
-        {
-
-            var m_AppWindow = GetAppWindowForCurrentWindow();
-            double scaleAdjustment = GetScaleAdjustment(GetWindowhWnd());
-
-            List<Windows.Graphics.RectInt32> dragRectsList = new();
-
-            Windows.Graphics.RectInt32 dragRect;
-            dragRect.X = (int)(LeftPaddingColumn.ActualWidth * scaleAdjustment);
-            dragRect.Y = 0;
-            dragRect.Height = (int)(AppTitleBar.ActualHeight * scaleAdjustment);
-            dragRect.Width = (int)(DragColumn.ActualWidth * scaleAdjustment); ;
-            dragRectsList.Add(dragRect);
-
-
-
-            Windows.Graphics.RectInt32[] dragRects = dragRectsList.ToArray();
-
-            m_AppWindow.TitleBar.SetDragRectangles(dragRects);
-        }
-        private Microsoft.UI.Windowing.AppWindow GetAppWindowForCurrentWindow()
-        {
-            WindowId wndId = Microsoft.UI.Win32Interop.GetWindowIdFromWindow(GetWindowhWnd());
-            return Microsoft.UI.Windowing.AppWindow.GetFromWindowId(wndId);
-        }
-        private IntPtr GetWindowhWnd()
-        {
-            var appcoreWindow = CoreWindow.GetForCurrentThread();
-            var interop = appcoreWindow.As<ICoreWindowInterop>();
-            return interop.WindowHandle;
+            RectInt32 Rect = new((ActualWidth - DragRegion.ActualWidth).GetActualPixel(), 0, DragRegion.ActualWidth.GetActualPixel(), DragRegion.ActualHeight.GetActualPixel());
+            Window.Current.CoreWindow.GetAppWindow().TitleBar.SetDragRectangles([Rect]);
         }
     }
 }


### PR DESCRIPTION
According to https://learn.microsoft.com/en-us/windows/apps/develop/title-bar?tabs=wasdk , we can customize drag region by obtaining the AppWindow instance with hWnd using ICoreWindowInterop.